### PR TITLE
Add option to ffmpeg settings

### DIFF
--- a/VideoFileResizer.ps1
+++ b/VideoFileResizer.ps1
@@ -56,6 +56,7 @@ if($Program -eq "ffmpeg"){
 	$ffmpegOptions += "27" #CRF value (Higher is less quality)
 	$ffmpegOptions += "-c:a" #Audio codec flag
 	$ffmpegOptions += "aac" #Specify aac for audio codec
+	$ffmpegOptions += "-hide_banner" #Hide top banner on  each encode
 }
 
 # Create Variable for storing the current directory


### PR DESCRIPTION
Add -hide_banner to default FFmpeg options. No reason we need to see the banner for every encode.